### PR TITLE
Add endpoint as part of ClusterRole rule

### DIFF
--- a/deploy/kube-templates/glusterblock-provisioner.yaml
+++ b/deploy/kube-templates/glusterblock-provisioner.yaml
@@ -31,6 +31,9 @@ items:
     - apiGroups: [""]
       resources: ["routes"]
       verbs: ["get", "list"]
+    - apiGroups: [""]
+      resources: ["endpoints"]
+      verbs: ["get", "list", "watch", "create", "update", "patch"]
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/deploy/ocp-templates/glusterblock-provisioner.yaml
+++ b/deploy/ocp-templates/glusterblock-provisioner.yaml
@@ -31,6 +31,9 @@ items:
     - apiGroups: [""]
       resources: ["routes"]
       verbs: ["get", "list"]
+    - apiGroups: [""]
+      resources: ["endpoints"]
+      verbs: ["get", "list", "watch", "create", "update", "patch"]
 - apiVersion: v1
   kind: ServiceAccount
   metadata:


### PR DESCRIPTION
endpoint is missing as part of ClusterRole rule.
This in turn throws a error when gluster-block pod is provisioned.

So, add ClusterRole to perform read/write with endpoint.

Note: endpoint is added in glusterblock-provisioner as part of
the PR: kubernetes-incubator/external-storage#957

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1723366

Signed-off-by: Saravanakumar <sarumuga@redhat.com>